### PR TITLE
Updates for MM 4.6 release

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,6 +1,18 @@
+Updates for MM 4.6 Release
+==========================
 
-# mattermost
-Bumped https://github.com/starkandwayne/mattermost-releases to v4.6.0
+New Config Options for Team Edition and Enterprise Edition
+---------------------
 
-# load-test
-Bumped https://github.com/starkandwayne/mattermost-releases to v4.6.0
+* ServiceSettings.EnableTutorial: true to control whether tutorial is shown to end users after account creation. This setting is experimental and may be replaced or removed in a future release.
+* TeamSettings.ExperimentalPrimaryTeam: set the primary team of the server. This setting is experimental and may be replaced or removed in a future release.
+* EmailSettings.LoginButtonColor: to set the style of the email login button for white labelling purposes.
+* EmailSettings.LoginButtonBorderColor: to set the style of the email login button for white labelling purposes.
+* EmailSettings.LoginButtonTextColor: to set the style of the email login button for white labelling purposes.
+
+New Config Options for Enterprise Edition
+-------------------------
+
+* LdapSettings.LoginButtonColor: to set the style of the LDAP login button for white labelling purposes.
+* LdapSettings.LoginButtonBorderColor: to set the style of the LDAP login button for white labelling purposes.
+* LdapSettings.LoginButtonTextColor: to set the style of the LDAP login button for white labelling purposes.

--- a/jobs/mattermost/spec
+++ b/jobs/mattermost/spec
@@ -164,6 +164,9 @@ properties:
   mattermost.ServiceSettings.ExperimentalEnableAuthenticationTransfer:
     description: Users can change their sign-in method to any that is enabled on the server
     default: true
+  mattermost.ServiceSettings.EnableTutorial: 
+    default: true
+    description: tutorial is shown to end users after account creation. This setting is experimental and may be replaced or removed in a future release.
    
   mattermost.TeamSettings.SiteName:
     description: Site name; it's not Slack, it is...
@@ -238,6 +241,9 @@ properties:
   mattermost.TeamSettings.EnableConfirmNotificationsToChannel:
     description: Users will be prompted to confirm when posting @channel and @all in channels with over five members.
     default: true
+  mattermost.TeamSettings.ExperimentalPrimaryTeam:
+    default: ""
+    description: to set the primary team of the server. This setting is experimental and may be replaced or removed in a future release.
 
   mattermost.SqlSettings.DriverName:
     description: Either 'postgres' or 'mysql'
@@ -482,6 +488,15 @@ properties:
   mattermost.EmailSettings.UseChannelInEmailNotifications:
     description: whether email notifications contain the channel name in the subject line
     default: false
+  mattermost.EmailSettings.LoginButtonColor:
+    default: ""
+    description: set the style of the email login button for white labelling purposes.
+  mattermost.EmailSettings.LoginButtonBorderColor:
+    default: ""
+    description: set the style of the email login button for white labelling purposes.
+  mattermost.EmailSettings.LoginButtonTextColor:
+    default: ""
+    description: set the style of the email login button for white labelling purposes.
 
   mattermost.LdapSettings.Enable:
     description: Mattermost allows login using AD/LDAP or Active Directory. (true|false)
@@ -543,7 +558,15 @@ properties:
   mattermost.LdapSettings.EnableSyncWithLdap:
     description: when true Mattermost periodically synchronizes SAML user attributes, including user deactivation and removal, with AD/LDAP
     default: false
-
+  mattermost.LdapSettings.LoginButtonColor: 
+    default: ""
+    description: to set the style of the LDAP login button for white labelling purposes.
+  mattermost.LdapSettings.LoginButtonBorderColor: 
+    default: ""
+    description: to set the style of the LDAP login button for white labelling purposes.
+  mattermost.LdapSettings.LoginButtonTextColor:
+    default: ""
+    description: to set the style of the LDAP login button for white labelling purposes.
 
   mattermost.ComplianceSettings.Enable:
     description: (E20) Compliance reporting is enabled in Mattermost. (true|false)

--- a/jobs/mattermost/templates/config/initial-config.json.erb
+++ b/jobs/mattermost/templates/config/initial-config.json.erb
@@ -71,7 +71,8 @@
         "SessionIdleTimeoutInMinutes": <%= p("mattermost.ServiceSettings.SessionIdleTimeoutInMinutes") %>,
         "CloseUnusedDirectMessages": <%= p("mattermost.ServiceSettings.CloseUnusedDirectMessages") %>,
         "EnablePreviewFeatures": <%= p("mattermost.ServiceSettings.EnablePreviewFeatures") %>, 
-        "ExperimentalEnableAuthenticationTransfer": <%= p("mattermost.ServiceSettings.ExperimentalEnableAuthenticationTransfer") %>
+        "ExperimentalEnableAuthenticationTransfer": <%= p("mattermost.ServiceSettings.ExperimentalEnableAuthenticationTransfer") %>,
+        "EnableTutorial": <%= p("mattermost.ServiceSettings.EnableTutorial") %>
     },
     "TeamSettings": {
         "SiteName": "<%= p("mattermost.TeamSettings.SiteName") %>",
@@ -97,7 +98,8 @@
         "UserStatusAwayTimeout": 300,
         "TeammateNameDisplay": "<%= p("mattermost.TeamSettings.TeammateNameDisplay") %>",
         "EnableXToLeaveChannelsFromLHS": <%= p("mattermost.TeamSettings.EnableXToLeaveChannelsFromLHS") %>,
-        "EnableConfirmNotificationsToChannel": <%= p("mattermost.TeamSettings.EnableConfirmNotificationsToChannel")%>
+        "EnableConfirmNotificationsToChannel": <%= p("mattermost.TeamSettings.EnableConfirmNotificationsToChannel")%>,
+        "ExperimentalPrimaryTeam": "<%= p("mattermost.TeamSettings.ExperimentalPrimaryTeam") %>"
     },
 
     "SqlSettings": {
@@ -178,7 +180,10 @@
         "SkipServerCertificateVerification": false,
         "EnableSMTPAuth": <%= p("mattermost.EmailSettings.EnableSMTPAuth") %>,
         "EmailNotificationContentType": "<%= p("mattermost.EmailSettings.EmailNotificationContentType") %>",
-        "UseChannelInEmailNotifications": <%= p("mattermost.EmailSettings.UseChannelInEmailNotifications") %>
+        "UseChannelInEmailNotifications": <%= p("mattermost.EmailSettings.UseChannelInEmailNotifications") %>,
+        "LoginButtonColor": "<%= p("mattermost.EmailSettings.LoginButtonColor") %>",
+        "LoginButtonBorderColor": "<%= p("mattermost.EmailSettings.LoginButtonBorderColor") %>",
+        "LoginButtonTextColor": "<%= p("mattermost.EmailSettings.LoginButtonTextColor") %>"
     },
     "RateLimitSettings": {
         "Enable": <%= p("mattermost.RateLimitSettings.Enable") %>,
@@ -249,7 +254,10 @@
         "QueryTimeout": <%= p("mattermost.LdapSettings.QueryTimeout") %>,
         "MaxPageSize": <%= p("mattermost.LdapSettings.MaxPageSize") %>,
         "LoginFieldName": "<%= p("mattermost.LdapSettings.LoginFieldName") %>",
-        "EnableSyncWithLdap": <%= p("mattermost.LdapSettings.EnableSyncWithLdap")%>
+        "EnableSyncWithLdap": <%= p("mattermost.LdapSettings.EnableSyncWithLdap")%>,
+        "LoginButtonColor": "<%= p("mattermost.LdapSettings.LoginButtonColor") %>",
+        "LoginButtonBorderColor": "<% p("mattermost.LdapSettings.LoginButtonBorderColor") %>",
+        "LoginButtonTextColor": "<% p("mattermost.LdapSettings.LoginButtonTextColor") %>"
     },
     <% end %>
     "ComplianceSettings": {


### PR DESCRIPTION
New Config Options for Team Edition and Enterprise Edition
---------------------

* ServiceSettings.EnableTutorial: true to control whether tutorial is shown to end users after account creation. This setting is experimental and may be replaced or removed in a future release.
* TeamSettings.ExperimentalPrimaryTeam: set the primary team of the server. This setting is experimental and may be replaced or removed in a future release.
* EmailSettings.LoginButtonColor: to set the style of the email login button for white labelling purposes.
* EmailSettings.LoginButtonBorderColor: to set the style of the email login button for white labelling purposes.
* EmailSettings.LoginButtonTextColor: to set the style of the email login button for white labelling purposes.

New Config Options for Enterprise Edition
-------------------------

* LdapSettings.LoginButtonColor: to set the style of the LDAP login button for white labelling purposes.
* LdapSettings.LoginButtonBorderColor: to set the style of the LDAP login button for white labelling purposes.
* LdapSettings.LoginButtonTextColor: to set the style of the LDAP login button for white labelling purposes.