### PR TITLE
Changes to Team Edition and Enterprise Edition:

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,9 @@
+Changes to Team Edition and Enterprise Edition:
+================
+
+* Under ServiceSettings in config.json:
+  * Added "ImageProxyType": "", "ImageProxyOptions": "", and "ImageProxyURL": "" to ensure posts served to the client will have their markdown modified such that all images are loaded through a proxy.
+  * Added "ExperimentalGroupUnreadChannels": disabled to show an unread channel section in the webapp sidebar. The setting must first be enabled by the System Admin, by replacing disabled with either default_off or default_on.
+  * Added "ExperimentalEnableDefaultChannelLeaveJoinMessages": true that allows disabling of leave/join messages in the default channel, usually Town Square.
+* Under RateLimitingSettings in config.json:
+  * Added "VaryByUser": false, a user-based rate limiting, to rate limit on token and on userID.

--- a/jobs/mattermost/spec
+++ b/jobs/mattermost/spec
@@ -167,6 +167,20 @@ properties:
   mattermost.ServiceSettings.EnableTutorial: 
     default: true
     description: tutorial is shown to end users after account creation. This setting is experimental and may be replaced or removed in a future release.
+  mattermost.ServiceSettings.ImageProxyType:
+    description: proxy type such as atmos/camo
+  mattermost.ServiceSettings.ImageProxyOptions: 
+    default: ""
+    description: Additional options for basic image adjustments such as the URL signing key. Contact your image proxy service provider to learn more about what options are supported.
+  mattermost.ServiceSettings.ImageProxyURL:
+    default: ""
+    description: URL of your image proxy server.
+  mattermost.ServiceSettings.ExperimentalGroupUnreadChannels:
+    default: disabled
+    description: show an unread channel section in the webapp sidebar. The setting must first be enabled by the System Admin, by replacing disabled with either default_off or default_on
+  mattermost.ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages:
+    default: true
+    description: allows disabling of leave/join messages in the default channel, usually Town Square.
    
   mattermost.TeamSettings.SiteName:
     description: Site name; it's not Slack, it is...
@@ -376,6 +390,9 @@ properties:
   mattermost.RateLimitSettings.VaryByHeader:
     description: Vary rate limiting by HTTP header field specified (""|X-Real-IP|X-Forwarded-For|anything you want)
     default: ""
+  mattermost.RateLimitSettings.VaryByUser:
+    default: false
+    description: user-based rate limiting, to rate limit on token and on userID.
 
   mattermost.PrivacySettings.ShowEmailAddress:
     description: Show email address of all users. (true|false)

--- a/jobs/mattermost/templates/config/initial-config.json.erb
+++ b/jobs/mattermost/templates/config/initial-config.json.erb
@@ -72,7 +72,14 @@
         "CloseUnusedDirectMessages": <%= p("mattermost.ServiceSettings.CloseUnusedDirectMessages") %>,
         "EnablePreviewFeatures": <%= p("mattermost.ServiceSettings.EnablePreviewFeatures") %>, 
         "ExperimentalEnableAuthenticationTransfer": <%= p("mattermost.ServiceSettings.ExperimentalEnableAuthenticationTransfer") %>,
-        "EnableTutorial": <%= p("mattermost.ServiceSettings.EnableTutorial") %>
+        "EnableTutorial": <%= p("mattermost.ServiceSettings.EnableTutorial") %>,
+        <% if_p("mattermost.ServiceSettings.ImageProxyType") do |proxyType| %>
+        "ImageProxyType": "<%= p("proxyType") %>",
+        "ImageProxyOptions":" <%= p("mattermost.ServiceSettings.ImageProxyOptions") %>", 
+        "ImageProxyURL": "<%= p("mattermost.ServiceSettings.ImageProxyURL") %>",
+        <% end %>
+        "ExperimentalGroupUnreadChannels": "<%= p("mattermost.ServiceSettings.ExperimentalGroupUnreadChannels") %>",
+        "ExperimentalEnableDefaultChannelLeaveJoinMessages":  <%= p("mattermost.ServiceSettings.ExperimentalEnableDefaultChannelLeaveJoinMessages") %>
     },
     "TeamSettings": {
         "SiteName": "<%= p("mattermost.TeamSettings.SiteName") %>",
@@ -191,7 +198,8 @@
         "MaxBurst": <%= p("mattermost.RateLimitSettings.MaxBurst") %>,
         "MemoryStoreSize": <%= p("mattermost.RateLimitSettings.MemoryStoreSize") %>,
         "VaryByRemoteAddr": <%= p("mattermost.RateLimitSettings.VaryByRemoteAddr") %>,
-        "VaryByHeader": "<%= p("mattermost.RateLimitSettings.VaryByHeader") %>"
+        "VaryByHeader": "<%= p("mattermost.RateLimitSettings.VaryByHeader") %>",
+        "VaryByUser": <%= p("mattermost.RateLimitSettings.VaryByUser") %>
     },
     "PrivacySettings": {
         "ShowEmailAddress": <%= p("mattermost.PrivacySettings.ShowEmailAddress") %>,


### PR DESCRIPTION
================

* Under ServiceSettings in config.json:
  * Added "ImageProxyType": "", "ImageProxyOptions": "", and "ImageProxyURL": "" to ensure posts served to the client will have their markdown modified such that allimages are loaded through a proxy.  * Added "ExperimentalGroupUnreadChannels": disabled to show an unread channel section in the webapp sidebar. The setting must first be enabled by the System Admin,by replacing disabled with either default_off or default_on.  * Added "ExperimentalEnableDefaultChannelLeaveJoinMessages": true that allows disabling of leave/join messages in the default channel, usually Town Square.* Under RateLimitingSettings in config.json:
  * Added "VaryByUser": false, a user-based rate limiting, to rate limit on token and on userID.